### PR TITLE
Add separate app-manager group

### DIFF
--- a/group.master
+++ b/group.master
@@ -59,3 +59,4 @@ ntp:x:119:
 metrics:x:120:
 systemd-journal:x:121:
 geoclue:x:122:
+app-manager:x:123:

--- a/passwd.master
+++ b/passwd.master
@@ -32,4 +32,4 @@ ntp:*:112:119::/home/ntp:/usr/sbin/nologin
 metrics:*:113:120:Endless Metrics Daemon::/usr/sbin/nologin
 geoclue:*:114:122::/var/lib/geoclue:/usr/sbin/nologin
 speech-dispatcher:*:115:29:Speech Dispatcher,,,:/var/run/speech-dispatcher:/usr/sbin/nologin
-app-manager:*:116:65534:Endless App Manager:/var/endless:/usr/sbin/nologin
+app-manager:*:116:123:Endless App Manager:/var/endless:/usr/sbin/nologin


### PR DESCRIPTION
Although there are probably not any issues in practice with having
app-manager part of nogroup, it's cleaner to have the app-manager user
totally isolated so that the files it creates in /var/endless don't
somehow become writable by unintended users.

[endlessm/eos-shell#2915]
