### PR TITLE
Update uuid-runtime user and group per latest util-linux

### DIFF
--- a/group.master
+++ b/group.master
@@ -37,7 +37,7 @@ staff:*:50:
 games:*:60:
 users:*:100:
 nogroup:*:65534:
-libuuid:x:101:
+uuidd:x:101:
 crontab:x:102:
 fuse:x:103:
 ssl-cert:x:104:

--- a/passwd.master
+++ b/passwd.master
@@ -16,7 +16,7 @@ list:*:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
 irc:*:39:39:ircd:/var/run/ircd:/usr/sbin/nologin
 gnats:*:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
 nobody:*:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
-libuuid:*:100:101::/var/lib/libuuid:/usr/sbin/nologin
+uuidd:x:100:101::/run/uuidd:/bin/false
 messagebus:*:101:105::/var/run/dbus:/usr/sbin/nologin
 avahi:*:102:106:Avahi mDNS daemon,,,:/var/run/avahi-daemon:/usr/sbin/nologin
 usbmux:*:103:46:usbmux daemon,,,:/home/usbmux:/usr/sbin/nologin


### PR DESCRIPTION
The update to util-linux-2.25.2 brought with it a change in the user and
group created by the uuid-runtime package. They've been changed from
libuuid to uuidd. The user's home directory and login shell have also
been changed to match the debian packaging.

[endlessm/eos-shell#4288]