### PR TITLE
Add ndn-user user and group

### DIFF
--- a/group.master
+++ b/group.master
@@ -66,3 +66,4 @@ systemd-coredump:*:126:
 vboxsf:*:127:
 kalite:*:128:
 g-s-helper:*:129:
+ndn-user:*:130:

--- a/passwd.master
+++ b/passwd.master
@@ -39,3 +39,4 @@ sshd:*:119:65534::/var/run/sshd:/usr/sbin/nologin
 systemd-coredump:*:120:126:systemd core dump processing,,,:/run/systemd:/bin/false
 kalite:*:121:128:KA Lite Helper system user,,,:/var/lib/kalite/:/bin/bash
 g-s-helper:*:122:129:GNOME Software helper system user,,,:/var/lib/g-s-helper/:/usr/sbin/nologin
+ndn-user:*:123:130::/var/lib/ndn:/bin/false


### PR DESCRIPTION
Needed for NDN; they’re normally added in the postinst scripts for
the ndn-cxx and nfd packages.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T14639

https://phabricator.endlessm.com/T13932