### PR TITLE
passwd: Use /bin/false for companion-app-helper

### DIFF
--- a/passwd.master
+++ b/passwd.master
@@ -42,4 +42,4 @@ g-s-helper:*:122:129:GNOME Software helper system user,,,:/var/lib/g-s-helper/:/
 ndn-user:*:123:130::/var/lib/ndn:/bin/false
 systemd-network:*:124:131:systemd Network Management,,,:/run/systemd/netif:/bin/false
 systemd-resolve:*:125:132:systemd Resolver,,,:/run/systemd/resolve:/bin/false
-companion-app-helper:*:126:133:Companion Application helper system user,,,:/var/lib/companion-app/:/usr/sbin/nologin
+companion-app-helper:*:126:133:Companion Application helper system user,,,:/var/lib/companion-app/:/bin/false


### PR DESCRIPTION
Using /sbin/nologin makes it far more difficult to test the service
since we can't actually log in to the account using sudo.

https://phabricator.endlessm.com/T20310