### PR TITLE
Add gnome-initial-setup user to systemd-journal group

### DIFF
--- a/group.master
+++ b/group.master
@@ -57,7 +57,7 @@ Debian-gdm:*:117:
 elasticsearch:*:118:
 ntp:*:119:
 metrics:*:120:
-systemd-journal:*:121:
+systemd-journal:*:121:gnome-initial-setup
 geoclue:*:122:
 app-manager:*:123:
 input:*:124:


### PR DESCRIPTION
When eos-installer hits an error, it automatically runs eos-diagnostics
to capture more details, and gives the user a link to view the output
and/or saves it to the USB stick.  When run from a standalone
eosinstaller image, or when the user chooses Reformat during the FBE on
a live image, it runs as the gnome-initial-setup user, which was
previously neither a member of systemd-journal nor of adm, so could not
read the journal.

Since gnome-initial-setup is root-equivalent anyway – it can create
user accounts in the administrator group – allowing it read-only access
to the journal seems okay.

https://phabricator.endlessm.com/T19950