### PR TITLE
Remove eos-paygd user and group

### DIFF
--- a/group.master
+++ b/group.master
@@ -72,6 +72,5 @@ systemd-resolve:*:132:
 companion-app-helper:*:133:
 avahi-service-writers:*:134:
 mogwai-scheduled:*:135:
-eos-paygd:*:136:
 nm-openvpn:*:137:
 _flatpak:*:138:

--- a/passwd.master
+++ b/passwd.master
@@ -44,7 +44,6 @@ systemd-network:*:124:131:systemd Network Management,,,:/run/systemd/netif:/bin/
 systemd-resolve:*:125:132:systemd Resolver,,,:/run/systemd/resolve:/bin/false
 companion-app-helper:*:126:133:Companion Application helper system user,,,:/var/lib/eos-companion-app/:/bin/false
 mogwai-scheduled:*:127:135:Mogwai (Download Scheduler) Scheduling Daemon::/usr/sbin/nologin
-eos-paygd:*:128:136:Endless Pay As You Go Daemon::/usr/sbin/nologin
 _apt:*:129:65534::/nonexistent:/bin/false
 nm-openvpn:*:130:137:NetworkManager OpenVPN,,,:/var/lib/openvpn/chroot:/bin/false
 _flatpak:*:131:138:Flatpak System Helper User::/usr/sbin/nologin


### PR DESCRIPTION
Moving forward the plan is for eos-paygd to run as root[1], so remove
the eos-paygd user and group. This is also important because the factory
test script for Angaza provisioning uses the existence of the eos-paygd
user to decide which user to run the provisioning program as.

[1] https://github.com/endlessm/eos-payg/commit/6d72794eb

https://phabricator.endlessm.com/T27037