### PR TITLE
Add 'render' group for DRI render device nodes

### DIFF
--- a/group.master
+++ b/group.master
@@ -75,3 +75,4 @@ mogwai-scheduled:*:135:
 nm-openvpn:*:137:
 _flatpak:*:138:
 kolibri:*:139:
+render:*:140:


### PR DESCRIPTION
Upstream udev and Debian now set the group of `/dev/dri/renderD*` to
'render.

https://phabricator.endlessm.com/T29341