### PR TITLE
Add kvm group

### DIFF
--- a/group.master
+++ b/group.master
@@ -77,3 +77,4 @@ _flatpak:*:138:
 kolibri:*:139:
 render:*:140:
 systemd-timesync:*:141:
+kvm:*:142:


### PR DESCRIPTION
This is one of the groups required by udev, as listed in USERS AND
GROUPS section of systemd's README [1].

[1] https://github.com/endlessm/systemd/blob/master/README

https://phabricator.endlessm.com/T30229